### PR TITLE
Fix for PAM_USER env and more

### DIFF
--- a/shavee-bin/src/args.rs
+++ b/shavee-bin/src/args.rs
@@ -1,5 +1,3 @@
-const UNREACHABLE_CODE : &str = "Panic! Something unexpected happened! Please help by reporting it as a bug.";
-
 use std::env;
 use std::ffi::OsString;
 use clap::{App, Arg, crate_authors, crate_description, crate_name, crate_version};
@@ -148,13 +146,13 @@ impl Sargs {
 
         // The port arguments are <u16> or None (not entered by user)
         let port = arg.value_of("port")
-            .map(|p| p.parse::<u16>().expect(UNREACHABLE_CODE));
+            .map(|p| p.parse::<u16>().expect(shavee_lib::logic::UNREACHABLE_CODE));
 
         // The accepted slot arguments are Some (1 or 2) or None (not entered by user)
         // Default value if not entered is 2
         let yslot = match arg.value_of("slot") {
             // exceptions should not happen, because the entry is already validated by clap
-            Some(s)   => s.parse::<u8>().expect (UNREACHABLE_CODE), 
+            Some(s)   => s.parse::<u8>().expect (shavee_lib::logic::UNREACHABLE_CODE), 
             None  => 2,
         };
 

--- a/shavee-bin/src/main.rs
+++ b/shavee-bin/src/main.rs
@@ -1,90 +1,54 @@
 mod args;
 
-use args::Sargs;
+use args::{Sargs, Mode, Umode};
 use base64::encode_config;
 use shavee_lib::logic::{create_zfs_file, create_zfs_yubi, unlock_zfs_pass};
 use shavee_lib::logic::{print_mode_file, print_mode_yubi, unlock_zfs_file, unlock_zfs_yubi};
 use shavee_lib::password::hash_argon2;
 use shavee_lib::zfs::*;
+use std::error::Error;
 use std::process::exit;
 
+// main() collect the arguments from command line, pass them to run() and print any error 
+// message upon exiting the program
 fn main() {
     let args = Sargs::new();
-    let pass = rpassword::prompt_password_stderr("Dataset Password: ");
-    let pass = match pass {
-        Ok(pass) => pass,
-        Err(error) => {
-            eprintln!("Error: Failed to read Password");
-            eprintln!("Error: {}", error);
-            exit(1)
-        }
-    };
 
-    match args.umode.as_str() {
-        "yubikey" => match args.mode.as_str() {
-            "print" => match print_mode_yubi(pass, args.yslot) {
-                Ok(()) => exit(0),
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    exit(1)
-                }
-            },
-            "pam" | "mount" => match unlock_zfs_yubi(pass, args.dataset, args.yslot) {
-                Ok(()) => exit(0),
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    exit(1)
-                }
-            },
-            "create" => match create_zfs_yubi(pass, args.dataset, args.yslot) {
-                Ok(()) => exit(0),
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    exit(1)
-                }
-            },
-            _ => unreachable!(),
+    // Only main() will terminate the executable with proper error message and code
+    exit(match run(args){
+        Ok(()) => 0,
+        Err(error) => {
+            eprintln!("Error: {}", error);
+            1
+        }
+    });
+}
+
+
+fn run(args: Sargs) -> Result<(), Box<dyn Error>> {
+
+    let pass = rpassword::prompt_password_stderr("Dataset Password: ")
+        .map_err(|e| e.to_string())?;
+
+    Ok(match args.umode {
+        Umode::Yubikey => match args.mode {
+            Mode::Print => print_mode_yubi(pass, args.yslot)?,
+            Mode::Mount => unlock_zfs_yubi(pass, args.dataset, args.yslot)?,
+            Mode::Create => create_zfs_yubi(pass, args.dataset, args.yslot)?,
         },
-        "file" => match args.mode.as_str() {
-            "print" => match print_mode_file(pass, &args.file, args.port) {
-                Ok(()) => exit(0),
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    exit(1)
-                }
-            },
-            "pam" | "mount" => match unlock_zfs_file(pass, args.file, args.dataset, args.port) {
-                Ok(()) => exit(0),
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    exit(1)
-                }
-            },
-            "create" => match create_zfs_file(pass, args.file, args.dataset, args.port) {
-                Ok(()) => exit(0),
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    exit(1)
-                }
-            },
-            _ => unreachable!(),
+        Umode::File => match args.mode {
+            Mode::Print => print_mode_file(pass, args.file, args.port)?,
+            Mode::Mount => unlock_zfs_file(pass, args.file, args.dataset, args.port)?,
+            Mode::Create => create_zfs_file(pass, args.file, args.dataset, args.port)?,
         },
-        "password" => {
-            let key = hash_argon2(pass.into_bytes()).unwrap();
+        Umode::Password => {
+            let key =  hash_argon2(pass.into_bytes())?;
             let key = encode_config(key, base64::STANDARD_NO_PAD);
-            match args.mode.as_str() {
-                "print" => println!("{}", key),
-                "pam" | "mount" => unlock_zfs_pass(key, args.dataset).unwrap(),
-                "create" => match zfs_create(key, args.dataset) {
-                    Ok(()) => (),
-                    Err(e) => {
-                        eprintln!("Error: {}", e);
-                        exit(1)
-                    }
-                },
-                _ => unreachable!(),
+            match args.mode {
+                Mode::Print => println!("{}", key),
+                Mode::Mount => unlock_zfs_pass(key, args.dataset)?,
+                Mode::Create => zfs_create(key, args.dataset)?,
             }
         }
-        _ => unreachable!(),
-    }
+    })
 }

--- a/shavee-bin/src/main.rs
+++ b/shavee-bin/src/main.rs
@@ -2,12 +2,13 @@ mod args;
 
 use args::{Sargs, Mode, Umode};
 use base64::encode_config;
-use shavee_lib::logic::{create_zfs_file, create_zfs_yubi, unlock_zfs_pass};
-use shavee_lib::logic::{print_mode_file, print_mode_yubi, unlock_zfs_file, unlock_zfs_yubi};
+use shavee_lib::logic::*;
 use shavee_lib::password::hash_argon2;
+use shavee_lib::filehash::get_filehash;
 use shavee_lib::zfs::*;
 use std::error::Error;
 use std::process::exit;
+use std::thread;
 
 // main() collect the arguments from command line, pass them to run() and print any error 
 // message upon exiting the program
@@ -27,8 +28,40 @@ fn main() {
 
 fn run(args: Sargs) -> Result<(), Box<dyn Error>> {
 
+    // pre-initialize the handle and filehash and use them
+    // if multithread is needed for file hash generation
+    // if multithread file hash code called then handle must not be used
+    // thus initializing it with an error message.
+    let mut handle: thread::JoinHandle<Result<Vec<u8>, String>> =
+        thread::spawn(|| Err(String::from(shavee_lib::logic::UNREACHABLE_CODE)) );
+    let mut filehash : Vec<u8> = vec![]; //empty u8 vector
+    
+    // if in the file 2FA mode, then generate file hash in parallel
+    // while user is entering password
+    if args.umode == Umode::File {
+        let file = args.file.clone()
+                .expect(shavee_lib::logic::UNREACHABLE_CODE);
+        let port = args.port.clone();
+
+        // start the file hash thread
+        handle = thread::spawn(move || {
+                get_filehash(file, port)
+                    .map_err(|e| e.to_string()) // map error to String
+            });
+    };
+
+    // prompt user for password, if case of error terminate this function and
+    // return the error to the calling function
     let pass = rpassword::prompt_password_stderr("Dataset Password: ")
         .map_err(|e| e.to_string())?;
+
+    // if in the file 2FA mode, then wait for hash generation thread to finish 
+    // and unwrap the result. In case of error, terminate this function and
+    // return error to the calling function.
+    if args.umode == Umode::File {
+        filehash = handle.join()
+            .unwrap()?;
+    };
 
     Ok(match args.umode {
         Umode::Yubikey => match args.mode {
@@ -37,9 +70,9 @@ fn run(args: Sargs) -> Result<(), Box<dyn Error>> {
             Mode::Create => create_zfs_yubi(pass, args.dataset, args.yslot)?,
         },
         Umode::File => match args.mode {
-            Mode::Print => print_mode_file(pass, args.file, args.port)?,
-            Mode::Mount => unlock_zfs_file(pass, args.file, args.dataset, args.port)?,
-            Mode::Create => create_zfs_file(pass, args.file, args.dataset, args.port)?,
+            Mode::Print => print_mode_file(pass, filehash)?,
+            Mode::Mount => unlock_zfs_file(pass, filehash, args.dataset)?,
+            Mode::Create => create_zfs_file(pass, filehash, args.dataset)?,
         },
         Umode::Password => {
             let key =  hash_argon2(pass.into_bytes())?;

--- a/shavee-lib/src/logic.rs
+++ b/shavee-lib/src/logic.rs
@@ -1,3 +1,5 @@
+pub const UNREACHABLE_CODE : &str = "Panic! Something unexpected happened! Please help by reporting it as a bug.";
+
 use crate::filehash::get_filehash;
 use crate::password::hash_argon2;
 use crate::yubikey::*;
@@ -5,42 +7,59 @@ use crate::zfs::*;
 use base64::encode_config;
 use std::error::Error;
 
+fn yubi_key_calculation(pass: String, slot: u8) -> Result<String, Box<dyn Error>> {
+    let key = yubikey_get_hash(pass, slot)?;
+    Ok(encode_config(key, base64::STANDARD_NO_PAD))
+}
 
 pub fn print_mode_yubi(pass: String, slot: u8) -> Result<(), Box<dyn Error>> {
-    let key = yubikey_get_hash(pass, slot)?; // Get encryption key
-    let key = encode_config(key, base64::STANDARD_NO_PAD);
+    let key = yubi_key_calculation(pass, slot)?;
     println!("{}", key);
     Ok(())
 }
 
-pub fn print_mode_file(pass: String, file: &String, port: u16) -> Result<(), Box<dyn Error>> {
-    let passhash = hash_argon2(pass.into_bytes())?;
-    let filehash = get_filehash(file.clone(), port)?;
-    let key = [filehash, passhash].concat();
-    let key = hash_argon2(key)?;
-    let key = encode_config(key, base64::STANDARD_NO_PAD);
-    println!("{}", key);
-    Ok(())
-}
+pub fn unlock_zfs_yubi(pass: String, dataset: Option<String>, slot: u8) -> Result<(), Box<dyn Error>> {
+    let dataset = dataset
+        .expect(UNREACHABLE_CODE);
 
-pub fn unlock_zfs_yubi(pass: String, dataset: String, slot: u8) -> Result<(), Box<dyn Error>> {
-    let key = yubikey_get_hash(pass, slot)?; // Get encryption key
-    let key = encode_config(key, base64::STANDARD_NO_PAD);
+    let key = yubi_key_calculation(pass, slot)?;
     zfs_loadkey(key, dataset.clone())?;
     zfs_mount(dataset)?;
     Ok(())
 }
 
-pub fn unlock_zfs_file(
-    pass: String,
-    file: String,
-    dataset: String,
-    port: u16,
-) -> Result<(), Box<dyn Error>> {
+pub fn create_zfs_yubi(pass: String, zfspath: Option<String>, slot: u8) -> Result<(), Box<dyn Error>> {
+    let key = yubi_key_calculation(pass, slot)?;
+    zfs_create(key, zfspath)?;
+    Ok(())
+}
+
+fn file_key_calculation(pass: String, file: Option<String>, port: Option<u16>) -> Result<String, Box<dyn Error>> {
+    let file = file
+        .expect(UNREACHABLE_CODE);
     let passhash = hash_argon2(pass.into_bytes())?;
     let filehash = get_filehash(file.clone(), port)?;
     let key = [filehash, passhash].concat();
-    let key = encode_config(hash_argon2(key)?, base64::STANDARD_NO_PAD);
+    let key = hash_argon2(key)?;
+    let key = encode_config(key, base64::STANDARD_NO_PAD);
+    Ok(key)
+}
+
+pub fn print_mode_file(pass: String, file: Option<String>, port: Option<u16>) -> Result<(),Box<dyn Error>> {
+    let key = file_key_calculation(pass, file, port)?;
+    println!("{}", key);
+    Ok(())
+}
+
+pub fn unlock_zfs_file(
+    pass: String,
+    file: Option<String>,
+    dataset: Option<String>,
+    port: Option<u16>
+) -> Result<(),Box<dyn Error>> {
+    let dataset = dataset
+        .expect(UNREACHABLE_CODE);
+    let key = file_key_calculation(pass, file, port)?;
     zfs_loadkey(key, dataset.clone())?;
     zfs_mount(dataset)?;
     Ok(())
@@ -48,26 +67,19 @@ pub fn unlock_zfs_file(
 
 pub fn create_zfs_file(
     pass: String,
-    file: String,
-    dataset: String,
-    port: u16,
+    file: Option<String>,
+    dataset: Option<String>,
+    port: Option<u16>
 ) -> Result<(), Box<dyn Error>> {
-    let passhash = hash_argon2(pass.into_bytes())?;
-
-    let filehash = get_filehash(file.clone(), port)?;
-    let key = [filehash, passhash].concat();
-    let key = encode_config(hash_argon2(key)?, base64::STANDARD_NO_PAD);
+    let key = file_key_calculation(pass, file, port)?;
     zfs_create(key, dataset)?;
     Ok(())
 }
 
-pub fn create_zfs_yubi(pass: String, zfspath: String, slot: u8) -> Result<(), Box<dyn Error>> {
-    let key = encode_config(yubikey_get_hash(pass, slot)?, base64::STANDARD_NO_PAD); // Get encryption key
-    zfs_create(key, zfspath)?;
-    Ok(())
-}
 
-pub fn unlock_zfs_pass(key: String, dataset: String) -> Result<(), Box<dyn Error>> {
+pub fn unlock_zfs_pass(key: String, dataset: Option<String>) -> Result<(), Box<dyn Error>> {
+    let dataset = dataset
+        .expect(UNREACHABLE_CODE);
     match zfs_list(dataset.clone()) {
         Ok(i) => {
             zfs_loadkey(key, dataset)?;

--- a/shavee-lib/src/zfs.rs
+++ b/shavee-lib/src/zfs.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::io::prelude::*;
 use std::process::Command;
+use crate::logic::UNREACHABLE_CODE;
 
 pub fn zfs_loadkey(key: String, dataset: String) -> Result<(), Box<dyn Error>> {
     let zfs = Command::new("zfs") // Call zfs mount
@@ -74,7 +75,9 @@ pub fn zfs_list(dataset: String) -> Result<Vec<String>, Box<dyn Error>> {
     return Ok(dlist);
 }
 
-pub fn zfs_create(key: String, dataset: String) -> Result<(), Box<dyn Error>> {
+pub fn zfs_create(key: String, dataset: Option<String>) -> Result<(), Box<dyn Error>> {
+    let dataset = dataset
+        .expect(UNREACHABLE_CODE);
     let zfs_list = Command::new("zfs")
         .arg("list")
         .arg("-H")

--- a/shavee-pam/src/lib.rs
+++ b/shavee-pam/src/lib.rs
@@ -26,7 +26,7 @@ impl PamServiceModule for PamShavee {
             .to_string_lossy()
             .to_string();
 
-        match shavee_lib::logic::unlock_zfs_yubi(pass, dataset, 2) {
+        match shavee_lib::logic::unlock_zfs_yubi(pass, Some(dataset), 2) {
             Ok(_) => return PamError::SUCCESS,
             Err(_) => return PamError::AUTH_ERR,
         }


### PR DESCRIPTION
This PR contains:

1. Fix for bug #7 
   * **NOTE**: The associated unit test is still not able to test for this bug and possible regression can happen.
2. Refactored code to make `main()` only for entry and exit. This helps in integration test implementation.
3. Added `Option<>` support to `Sargs` and related codes.
4. Refactored key calculation into a separate function to eliminate repeated codes.