### PR TITLE
'size' and parallel hash generation

### DIFF
--- a/shavee-bin/src/args.rs
+++ b/shavee-bin/src/args.rs
@@ -1,5 +1,3 @@
-const UNREACHABLE_CODE : &str = "Panic! Something unexpected happened! Please help by reporting it as a bug.";
-
 use std::env;
 use std::ffi::OsString;
 use clap::{App, Arg, crate_authors, crate_description, crate_name, crate_version};
@@ -148,13 +146,13 @@ impl Sargs {
 
         // The port arguments are <u16> or None (not entered by user)
         let port = arg.value_of("port")
-            .map(|p| p.parse::<u16>().expect(UNREACHABLE_CODE));
+            .map(|p| p.parse::<u16>().expect(shavee_lib::logic::UNREACHABLE_CODE));
 
         // The accepted slot arguments are Some (1 or 2) or None (not entered by user)
         // Default value if not entered is 2
         let yslot = match arg.value_of("slot") {
             // exceptions should not happen, because the entry is already validated by clap
-            Some(s)   => s.parse::<u8>().expect (UNREACHABLE_CODE), 
+            Some(s)   => s.parse::<u8>().expect (shavee_lib::logic::UNREACHABLE_CODE), 
             None  => 2,
         };
 

--- a/shavee-bin/src/main.rs
+++ b/shavee-bin/src/main.rs
@@ -1,90 +1,54 @@
 mod args;
 
-use args::Sargs;
+use args::{Sargs, Mode, Umode};
 use base64::encode_config;
 use shavee_lib::logic::{create_zfs_file, create_zfs_yubi, unlock_zfs_pass};
 use shavee_lib::logic::{print_mode_file, print_mode_yubi, unlock_zfs_file, unlock_zfs_yubi};
 use shavee_lib::password::hash_argon2;
 use shavee_lib::zfs::*;
+use std::error::Error;
 use std::process::exit;
 
+// main() collect the arguments from command line, pass them to run() and print any error 
+// message upon exiting the program
 fn main() {
     let args = Sargs::new();
-    let pass = rpassword::prompt_password_stderr("Dataset Password: ");
-    let pass = match pass {
-        Ok(pass) => pass,
-        Err(error) => {
-            eprintln!("Error: Failed to read Password");
-            eprintln!("Error: {}", error);
-            exit(1)
-        }
-    };
 
-    match args.umode.as_str() {
-        "yubikey" => match args.mode.as_str() {
-            "print" => match print_mode_yubi(pass, args.yslot) {
-                Ok(()) => exit(0),
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    exit(1)
-                }
-            },
-            "pam" | "mount" => match unlock_zfs_yubi(pass, args.dataset, args.yslot) {
-                Ok(()) => exit(0),
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    exit(1)
-                }
-            },
-            "create" => match create_zfs_yubi(pass, args.dataset, args.yslot) {
-                Ok(()) => exit(0),
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    exit(1)
-                }
-            },
-            _ => unreachable!(),
+    // Only main() will terminate the executable with proper error message and code
+    exit(match run(args){
+        Ok(()) => 0,
+        Err(error) => {
+            eprintln!("Error: {}", error);
+            1
+        }
+    });
+}
+
+
+fn run(args: Sargs) -> Result<(), Box<dyn Error>> {
+
+    let pass = rpassword::prompt_password_stderr("Dataset Password: ")
+        .map_err(|e| e.to_string())?;
+
+    Ok(match args.umode {
+        Umode::Yubikey => match args.mode {
+            Mode::Print => print_mode_yubi(pass, args.yslot)?,
+            Mode::Mount => unlock_zfs_yubi(pass, args.dataset, args.yslot)?,
+            Mode::Create => create_zfs_yubi(pass, args.dataset, args.yslot)?,
         },
-        "file" => match args.mode.as_str() {
-            "print" => match print_mode_file(pass, &args.file, args.port) {
-                Ok(()) => exit(0),
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    exit(1)
-                }
-            },
-            "pam" | "mount" => match unlock_zfs_file(pass, args.file, args.dataset, args.port) {
-                Ok(()) => exit(0),
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    exit(1)
-                }
-            },
-            "create" => match create_zfs_file(pass, args.file, args.dataset, args.port) {
-                Ok(()) => exit(0),
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    exit(1)
-                }
-            },
-            _ => unreachable!(),
+        Umode::File => match args.mode {
+            Mode::Print => print_mode_file(pass, args.file, args.port)?,
+            Mode::Mount => unlock_zfs_file(pass, args.file, args.dataset, args.port)?,
+            Mode::Create => create_zfs_file(pass, args.file, args.dataset, args.port)?,
         },
-        "password" => {
-            let key = hash_argon2(pass.into_bytes()).unwrap();
+        Umode::Password => {
+            let key =  hash_argon2(pass.into_bytes())?;
             let key = encode_config(key, base64::STANDARD_NO_PAD);
-            match args.mode.as_str() {
-                "print" => println!("{}", key),
-                "pam" | "mount" => unlock_zfs_pass(key, args.dataset).unwrap(),
-                "create" => match zfs_create(key, args.dataset) {
-                    Ok(()) => (),
-                    Err(e) => {
-                        eprintln!("Error: {}", e);
-                        exit(1)
-                    }
-                },
-                _ => unreachable!(),
+            match args.mode {
+                Mode::Print => println!("{}", key),
+                Mode::Mount => unlock_zfs_pass(key, args.dataset)?,
+                Mode::Create => zfs_create(key, args.dataset)?,
             }
         }
-        _ => unreachable!(),
-    }
+    })
 }

--- a/shavee-bin/src/main.rs
+++ b/shavee-bin/src/main.rs
@@ -2,12 +2,13 @@ mod args;
 
 use args::{Sargs, Mode, Umode};
 use base64::encode_config;
-use shavee_lib::logic::{create_zfs_file, create_zfs_yubi, unlock_zfs_pass};
-use shavee_lib::logic::{print_mode_file, print_mode_yubi, unlock_zfs_file, unlock_zfs_yubi};
+use shavee_lib::logic::*;
 use shavee_lib::password::hash_argon2;
+use shavee_lib::filehash::get_filehash;
 use shavee_lib::zfs::*;
 use std::error::Error;
 use std::process::exit;
+use std::thread;
 
 // main() collect the arguments from command line, pass them to run() and print any error 
 // message upon exiting the program
@@ -27,8 +28,40 @@ fn main() {
 
 fn run(args: Sargs) -> Result<(), Box<dyn Error>> {
 
+    // pre-initialize the handle and filehash and use them
+    // if multithread is needed for file hash generation
+    // if multithread file hash code called then handle must not be used
+    // thus initializing it with an error message.
+    let mut handle: thread::JoinHandle<Result<Vec<u8>, String>> =
+        thread::spawn(|| Err(String::from(shavee_lib::logic::UNREACHABLE_CODE)) );
+    let mut filehash : Vec<u8> = vec![]; //empty u8 vector
+    
+    // if in the file 2FA mode, then generate file hash in parallel
+    // while user is entering password
+    if args.umode == Umode::File {
+        let file = args.file.clone()
+                .expect(shavee_lib::logic::UNREACHABLE_CODE);
+        let port = args.port.clone();
+
+        // start the file hash thread
+        handle = thread::spawn(move || {
+                get_filehash(file, port)
+                    .map_err(|e| e.to_string()) // map error to String
+            });
+    };
+
+    // prompt user for password, if case of error terminate this function and
+    // return the error to the calling function
     let pass = rpassword::prompt_password_stderr("Dataset Password: ")
         .map_err(|e| e.to_string())?;
+
+    // if in the file 2FA mode, then wait for hash generation thread to finish 
+    // and unwrap the result. In case of error, terminate this function and
+    // return error to the calling function.
+    if args.umode == Umode::File {
+        filehash = handle.join()
+            .unwrap()?;
+    };
 
     Ok(match args.umode {
         Umode::Yubikey => match args.mode {
@@ -37,9 +70,9 @@ fn run(args: Sargs) -> Result<(), Box<dyn Error>> {
             Mode::Create => create_zfs_yubi(pass, args.dataset, args.yslot)?,
         },
         Umode::File => match args.mode {
-            Mode::Print => print_mode_file(pass, args.file, args.port)?,
-            Mode::Mount => unlock_zfs_file(pass, args.file, args.dataset, args.port)?,
-            Mode::Create => create_zfs_file(pass, args.file, args.dataset, args.port)?,
+            Mode::Print => print_mode_file(pass, filehash)?,
+            Mode::Mount => unlock_zfs_file(pass, filehash, args.dataset)?,
+            Mode::Create => create_zfs_file(pass, filehash, args.dataset)?,
         },
         Umode::Password => {
             let key =  hash_argon2(pass.into_bytes())?;

--- a/shavee-lib/src/filehash.rs
+++ b/shavee-lib/src/filehash.rs
@@ -1,45 +1,96 @@
 use curl;
 use sha2::{Digest, Sha512};
-use std::io::{self, BufRead, BufReader};
 use std::error::Error;
+use std::io::{self, BufRead, BufReader};
 
-pub fn get_filehash(file: String, port: Option<u16>, size: Option<u64>) -> Result<Vec<u8>, Box<dyn Error>> {
+// max capacity must be a u32 number to be safely casted into usize independent of 32/64bit systems
+const MAX_BUFFER_CAPACITY: u32 = 1 << 24;
+
+pub fn get_filehash(
+    file: String,
+    port: Option<u16>,
+    size: Option<u64>,
+) -> Result<Vec<u8>, Box<dyn Error>> {
     if file.starts_with("https://") || file.starts_with("http://") || file.starts_with("sftp://") {
-        get_filehash_http_sftp(file, port, size)
-            .map_err(|e| e.into())
+        get_filehash_http_sftp(file, port, size).map_err(|e| e.into())
     } else {
-        get_filehash_local(file, size)
-            .map_err(|e| e.into())
+        get_filehash_local(file, size).map_err(|e| e.into())
     }
 }
 
-fn get_filehash_local(file: String, _size: Option<u64>) -> Result<Vec<u8>, io::Error> {
-    let inner_file = std::fs::File::open(&file)?;
+fn get_filehash_local(file: String, size: Option<u64>) -> Result<Vec<u8>, io::Error> {
+    let file_handle = std::fs::File::open(&file)?;
 
-    let cap: usize = 131072 * 128;
-    let mut reader = BufReader::with_capacity(cap, inner_file);
+    let mut remaining_bytes = size.clone();
+
+    // defult buffer capacity
+    let mut buffer_capacity = MAX_BUFFER_CAPACITY as usize;
+
+    // if "size" argument has provided, then check for its value and if its value is smaller than
+    // current buffer capacity then use "size" value for buffer capacity. Otherwise keep the default
+    if let Some(s) = size {
+        // depending on the system, usize is either 32 or 64bits and can be safely casted into u64
+        // however the other way is only possible if u64 variable is smaller than 32bits
+        if s < buffer_capacity as u64 {
+            // if "size" is smaller than default buffer capacity (const u32)
+            buffer_capacity = s as usize; // then buffer capacity will be reduced to "size"
+        };
+    };
+
+    let mut reader = BufReader::with_capacity(buffer_capacity, file_handle);
     let mut hasher = Sha512::new();
-    loop {
-        let length = {
+
+    // If "size" argument is passed then exit loop when unread remaining bytes are 0
+    // if no "size" argument (None), then the loop only exits if the file is completely processed (length == 0)
+    while remaining_bytes != Some(0) {
+        let mut length = {
+            // try to fill buffer and on failures exit function with error message
             let buffer = reader.fill_buf()?;
             hasher.update(buffer);
             buffer.len()
         };
+
+        // exit out of loop if reached end of file.
         if length == 0 {
             break;
         }
+
+        // Only if "size" argument is passed, then count the number of processed bytes
+        // If no "size" argument (None) then skip the byte counting.
+        if let Some(r) = remaining_bytes {
+            // as long as the remaining bytes are bigger than buffer, process buffer
+            // and substract it from remaining
+            if r >= length as u64 {
+                remaining_bytes = Some(r - length as u64);
+            }
+            //otherwise process only up to the remaining bytes and exit the loop
+            else {
+                length = r as usize;
+                remaining_bytes = Some(0);
+            }
+        }
+        // read length number of bytes
         reader.consume(length);
     }
+    // upon success generate hash and return as Ok(vector)
     Ok(hasher.finalize().to_vec())
 }
 
-fn get_filehash_http_sftp(file: String, port: Option<u16>, _size: Option<u64>) -> Result<Vec<u8>, curl::Error> {
+fn get_filehash_http_sftp(
+    file: String,
+    port: Option<u16>,
+    size: Option<u64>,
+) -> Result<Vec<u8>, curl::Error> {
     let mut rfile = curl::easy::Easy::new();
     let mut filehash = Sha512::new();
     rfile.url(file.as_str()).expect("Invalid URL");
 
     if port.is_some() {
         rfile.port(port.unwrap())?;
+    }
+    if size.is_some() {
+        let range = format!("0-{}", size.unwrap());
+        rfile.range(&range[..])?;
     }
 
     rfile.fail_on_error(true)?;
@@ -70,6 +121,7 @@ mod tests {
         #[derive(Debug, PartialEq)]
         struct FileHashResultPair {
             file: String,
+            size: Option<u64>,
             hash_result: Result<Vec<u8>, io::ErrorKind>,
         }
 
@@ -78,7 +130,8 @@ mod tests {
         // NOTE: These tests will fail if any of these files changes.
         let file_hash_result_pairs = [
             FileHashResultPair {
-                file: String::from("can_be_deleted.txt"), //zero size file
+                file: String::from("can_be_deleted.txt"),
+                size: None,
                 hash_result: Ok(vec![
                     151, 32, 184, 60, 202, 224, 90, 60, 197, 34, 2, 158, 175, 149, 203, 186, 104,
                     129, 90, 15, 210, 92, 87, 121, 209, 152, 85, 171, 231, 42, 7, 23, 47, 68, 173,
@@ -87,7 +140,38 @@ mod tests {
                 ]),
             },
             FileHashResultPair {
-                file: String::from("zero_size.txt"), //zero size file
+                file: String::from("can_be_deleted.txt"),
+                size: Some(1 << 8), // size bigger than file
+                hash_result: Ok(vec![
+                    151, 32, 184, 60, 202, 224, 90, 60, 197, 34, 2, 158, 175, 149, 203, 186, 104,
+                    129, 90, 15, 210, 92, 87, 121, 209, 152, 85, 171, 231, 42, 7, 23, 47, 68, 173,
+                    1, 147, 112, 247, 149, 181, 52, 64, 220, 94, 197, 103, 139, 124, 253, 180, 130,
+                    87, 22, 146, 141, 51, 10, 47, 233, 163, 16, 124, 123,
+                ]),
+            },
+            FileHashResultPair {
+                file: String::from("can_be_deleted.txt"),
+                size: Some(1 << 63), // 64bit hash size
+                hash_result: Ok(vec![
+                    151, 32, 184, 60, 202, 224, 90, 60, 197, 34, 2, 158, 175, 149, 203, 186, 104,
+                    129, 90, 15, 210, 92, 87, 121, 209, 152, 85, 171, 231, 42, 7, 23, 47, 68, 173,
+                    1, 147, 112, 247, 149, 181, 52, 64, 220, 94, 197, 103, 139, 124, 253, 180, 130,
+                    87, 22, 146, 141, 51, 10, 47, 233, 163, 16, 124, 123,
+                ]),
+            },
+            FileHashResultPair {
+                file: String::from("can_be_deleted.txt"),
+                size: Some(2), // hash size smaller than file size
+                hash_result: Ok(vec![
+                    228, 239, 180, 180, 23, 58, 126, 30, 72, 208, 65, 207, 22, 167, 157, 234, 141,
+                    138, 136, 133, 187, 83, 207, 2, 140, 214, 242, 176, 75, 117, 70, 219, 172, 126,
+                    182, 37, 220, 176, 115, 126, 76, 109, 67, 142, 0, 180, 108, 22, 228, 137, 166,
+                    137, 86, 28, 144, 73, 28, 52, 171, 85, 27, 203, 99, 41,
+                ]),
+            },
+            FileHashResultPair {
+                file: String::from("can_be_deleted.txt"),
+                size: Some(0), // zero hash size
                 hash_result: Ok(vec![
                     207, 131, 225, 53, 126, 239, 184, 189, 241, 84, 40, 80, 214, 109, 128, 7, 214,
                     32, 228, 5, 11, 87, 21, 220, 131, 244, 169, 33, 211, 108, 233, 206, 71, 208,
@@ -96,11 +180,64 @@ mod tests {
                 ]),
             },
             FileHashResultPair {
+                file: String::from("zero_size.txt"), //zero size file
+                size: None,
+                hash_result: Ok(vec![
+                    207, 131, 225, 53, 126, 239, 184, 189, 241, 84, 40, 80, 214, 109, 128, 7, 214,
+                    32, 228, 5, 11, 87, 21, 220, 131, 244, 169, 33, 211, 108, 233, 206, 71, 208,
+                    209, 60, 93, 133, 242, 176, 255, 131, 24, 210, 135, 126, 236, 47, 99, 185, 49,
+                    189, 71, 65, 122, 129, 165, 56, 50, 122, 249, 39, 218, 62,
+                ]),
+            },
+            FileHashResultPair {
+                file: String::from("zero_size.txt"), //zero size file
+                size: Some(222),                     // size bigger than file
+                hash_result: Ok(vec![
+                    207, 131, 225, 53, 126, 239, 184, 189, 241, 84, 40, 80, 214, 109, 128, 7, 214,
+                    32, 228, 5, 11, 87, 21, 220, 131, 244, 169, 33, 211, 108, 233, 206, 71, 208,
+                    209, 60, 93, 133, 242, 176, 255, 131, 24, 210, 135, 126, 236, 47, 99, 185, 49,
+                    189, 71, 65, 122, 129, 165, 56, 50, 122, 249, 39, 218, 62,
+                ]),
+            },
+            FileHashResultPair {
+                file: String::from("/dev/zero"), // Zeros with no size limit
+                size: Some(1 << 8),              // Put limit on hash size
+                hash_result: Ok(vec![
+                    105, 63, 149, 213, 131, 131, 166, 22, 45, 42, 171, 73, 235, 96, 57, 93, 204,
+                    75, 178, 34, 149, 18, 12, 175, 63, 33, 227, 3, 144, 3, 35, 11, 40, 124, 86,
+                    106, 3, 199, 160, 202, 90, 204, 174, 210, 19, 60, 112, 11, 28, 179, 248, 46,
+                    223, 138, 220, 189, 220, 146, 180, 249, 251, 153, 16, 198,
+                ]),
+            },
+            /* // this entry significantly increases test time
+            FileHashResultPair {
+                file: String::from("/dev/zero"), // Zeros with no size limit
+                size: Some(1 << 34),             // Very large hash size (64bits)
+                hash_result: Ok(vec![
+                    13, 186, 138, 161, 49, 41, 63, 12, 151, 49, 59, 122, 116, 237, 203, 235, 0,
+                    212, 46, 1, 236, 69, 210, 102, 149, 176, 17, 18, 57, 179, 136, 45, 161, 205,
+                    169, 236, 52, 95, 145, 184, 230, 126, 195, 211, 183, 237, 186, 136, 104, 186,
+                    123, 230, 237, 157, 132, 255, 222, 7, 108, 235, 249, 17, 181, 211,
+                ]),
+            },*/
+            FileHashResultPair {
                 file: String::from("does_not_exists"), //Not Found
+                size: None,
+                hash_result: Err(io::ErrorKind::NotFound),
+            },
+            FileHashResultPair {
+                file: String::from("does_not_exists"), //Not Found
+                size: Some(11 << 5),                   // hash size for a Not Found
                 hash_result: Err(io::ErrorKind::NotFound),
             },
             FileHashResultPair {
                 file: String::from("no_read_permission.txt"), //no read permission
+                size: None,
+                hash_result: Err(io::ErrorKind::PermissionDenied),
+            },
+            FileHashResultPair {
+                file: String::from("no_read_permission.txt"), //no read permission
+                size: Some(111),                              // hash size for no read permission
                 hash_result: Err(io::ErrorKind::PermissionDenied),
             },
         ];
@@ -142,8 +279,9 @@ mod tests {
         for index in 0..file_hash_result_pairs.len() {
             let mut file = temp_folder.clone();
             file.push(file_hash_result_pairs[index].file.clone());
+            let size = file_hash_result_pairs[index].size.clone();
 
-            match get_filehash_local(file.into_os_string().into_string().unwrap(), None)
+            match get_filehash_local(file.into_os_string().into_string().unwrap(), size)
                 .map_err(|e| e.kind())
             {
                 Ok(v) => assert_eq!(
@@ -168,6 +306,7 @@ mod tests {
         #[derive(Debug, PartialEq)]
         struct FilePortHashResultPair {
             file: String,
+            size: Option<u64>,
             port: Option<u16>,
             hash_result: Result<Vec<u8>, curl::Error>,
         }
@@ -180,6 +319,7 @@ mod tests {
                 file: String::from(
                     "https://raw.githubusercontent.com/ashuio/shavee/master/LICENSE",
                 ),
+                size: None,
                 port: None,
                 hash_result: Ok(vec![
                     114, 198, 213, 139, 67, 213, 120, 43, 163, 13, 255, 110, 191, 190, 203, 251,
@@ -192,6 +332,7 @@ mod tests {
                 file: String::from(
                     "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
                 ),
+                size: None,
                 port: Some(443),
                 hash_result: Ok(vec![
                     243, 179, 171, 62, 99, 81, 226, 91, 92, 24, 130, 190, 168, 211, 126, 250, 221,
@@ -204,6 +345,7 @@ mod tests {
                 file: String::from(
                     "http://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
                 ),
+                size: None,
                 port: Some(80),
                 hash_result: Ok(vec![
                     243, 179, 171, 62, 99, 81, 226, 91, 92, 24, 130, 190, 168, 211, 126, 250, 221,
@@ -216,6 +358,7 @@ mod tests {
                 file: String::from(
                     "https://raw.githubusercontent.com/ashuio/shavee/master/LICENSEEEE",
                 ), //file doesn't exists
+                size: Some(1 << 10),
                 port: None,
                 hash_result: Err(curl::Error::new(22)), //CURLE_HTTP_RETURNED_ERROR
             },
@@ -223,11 +366,13 @@ mod tests {
                 file: String::from(
                     "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
                 ),
-                port: Some(80),                               //Wrong port for SSL
+                size: Some(1 << 32),
+                port: Some(80),                         //Wrong port for SSL
                 hash_result: Err(curl::Error::new(35)), //CURLE_SSL_CONNECT_ERROR
             },
             FilePortHashResultPair {
                 file: String::from("http://www.w3.ggg"), // host doesn't exists
+                size: Some(5),
                 port: None,
                 hash_result: Err(curl::Error::new(6)), //CURLE_COULDNT_RESOLVE_HOST
             },
@@ -235,7 +380,38 @@ mod tests {
                 file: String::from(
                     "http://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
                 ),
-                port: Some(23),                               //FTP port used for HTTP
+                size: Some(2048),
+                port: Some(23),                         //FTP port used for HTTP
+                hash_result: Err(curl::Error::new(28)), //CURLE_HTTP_RETURNED_ERROR
+            },
+            FilePortHashResultPair {
+                file: String::from(
+                    "https://raw.githubusercontent.com/ashuio/shavee/master/LICENSEEEE",
+                ), //file doesn't exists
+                size: Some(98),
+                port: None,
+                hash_result: Err(curl::Error::new(22)), //CURLE_HTTP_RETURNED_ERROR
+            },
+            FilePortHashResultPair {
+                file: String::from(
+                    "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
+                ),
+                size: Some(69820),
+                port: Some(80),                         //Wrong port for SSL
+                hash_result: Err(curl::Error::new(35)), //CURLE_SSL_CONNECT_ERROR
+            },
+            FilePortHashResultPair {
+                file: String::from("http://www.w3.ggg"), // host doesn't exists
+                size: Some(0),
+                port: None,
+                hash_result: Err(curl::Error::new(6)), //CURLE_COULDNT_RESOLVE_HOST
+            },
+            FilePortHashResultPair {
+                file: String::from(
+                    "http://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
+                ),
+                size: Some(256),
+                port: Some(23),                         //FTP port used for HTTP
                 hash_result: Err(curl::Error::new(28)), //CURLE_HTTP_RETURNED_ERROR
             },
         ];
@@ -243,8 +419,9 @@ mod tests {
         for index in 0..file_hash_result_pairs.len() {
             let file = file_hash_result_pairs[index].file.clone();
             let port = file_hash_result_pairs[index].port;
+            let size = file_hash_result_pairs[index].size;
 
-            match get_filehash_http_sftp(file, port, None) {
+            match get_filehash_http_sftp(file, port, size) {
                 Ok(v) => assert_eq!(
                     v,
                     file_hash_result_pairs[index].hash_result.clone().unwrap()
@@ -269,6 +446,7 @@ mod tests {
         // and their output hash results
         struct FilePortHashResultPair {
             file: String,
+            size: Option<u64>,
             port: Option<u16>,
             hash_result: Result<Vec<u8>, String>,
         }
@@ -278,7 +456,8 @@ mod tests {
         // NOTE: These tests will fail if any of these files changes.
         let file_hash_result_pairs = [
             FilePortHashResultPair {
-                file: String::from("can_be_deleted.txt"), //zero size file
+                file: String::from("can_be_deleted.txt"),
+                size: Some(1024),
                 port: None,
                 hash_result: Ok(vec![
                     151, 32, 184, 60, 202, 224, 90, 60, 197, 34, 2, 158, 175, 149, 203, 186, 104,
@@ -289,6 +468,7 @@ mod tests {
             },
             FilePortHashResultPair {
                 file: String::from("zero_size.txt"), //zero size file
+                size: Some(2048),
                 port: None,
                 hash_result: Ok(vec![
                     207, 131, 225, 53, 126, 239, 184, 189, 241, 84, 40, 80, 214, 109, 128, 7, 214,
@@ -299,11 +479,13 @@ mod tests {
             },
             FilePortHashResultPair {
                 file: String::from("does_not_exists"), //Not Found
+                size: Some(512),
                 port: None,
                 hash_result: Err(io::Error::from_raw_os_error(2).to_string()),
             },
             FilePortHashResultPair {
                 file: String::from("no_read_permission.txt"), //no read permission
+                size: Some(128),
                 port: None,
                 hash_result: Err(io::Error::from_raw_os_error(13).to_string()),
             },
@@ -311,6 +493,7 @@ mod tests {
                 file: String::from(
                     "https://raw.githubusercontent.com/ashuio/shavee/master/LICENSE",
                 ),
+                size: Some(1<<11),
                 port: None,
                 hash_result: Ok(vec![
                     114, 198, 213, 139, 67, 213, 120, 43, 163, 13, 255, 110, 191, 190, 203, 251,
@@ -323,6 +506,7 @@ mod tests {
                 file: String::from(
                     "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
                 ),
+                size: None,
                 port: Some(443),
                 hash_result: Ok(vec![
                     243, 179, 171, 62, 99, 81, 226, 91, 92, 24, 130, 190, 168, 211, 126, 250, 221,
@@ -335,6 +519,7 @@ mod tests {
                 file: String::from(
                     "http://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
                 ),
+                size: Some(1<<15),
                 port: Some(80),
                 hash_result: Ok(vec![
                     243, 179, 171, 62, 99, 81, 226, 91, 92, 24, 130, 190, 168, 211, 126, 250, 221,
@@ -347,6 +532,7 @@ mod tests {
                 file: String::from(
                     "https://raw.githubusercontent.com/ashuio/shavee/master/LICENSEEEE",
                 ), //file doesn't exists
+                size: Some(1<<10),
                 port: None,
                 hash_result: Err(curl::Error::new(22).to_string()), //CURLE_HTTP_RETURNED_ERROR
             },
@@ -354,11 +540,13 @@ mod tests {
                 file: String::from(
                     "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
                 ),
-                port: Some(80),                               //Wrong port for SSL
+                size: Some(1<<16),
+                port: Some(80), //Wrong port for SSL
                 hash_result: Err(curl::Error::new(35).to_string()), //CURLE_SSL_CONNECT_ERROR
             },
             FilePortHashResultPair {
                 file: String::from("http://www.w3.ggg"), // host doesn't exists
+                size: None,
                 port: None,
                 hash_result: Err(curl::Error::new(6).to_string()), //CURLE_COULDNT_RESOLVE_HOST
             },
@@ -366,7 +554,8 @@ mod tests {
                 file: String::from(
                     "http://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
                 ),
-                port: Some(23),                               //FTP port used for HTTP
+                size: Some(200 * 1<<10), //200kB
+                port: Some(23), //FTP port used for HTTP
                 hash_result: Err(curl::Error::new(28).to_string()), //CURLE_HTTP_RETURNED_ERROR
             },
         ];
@@ -410,18 +599,16 @@ mod tests {
 
             if !(file.starts_with("https://")
                 || file.starts_with("http://")
-                || file.starts_with("sftp://")) {
-                    let mut receive_file = temp_folder.clone();
-                    receive_file.push(file);
-                    file = receive_file
-                        .into_os_string()
-                        .into_string()
-                        .unwrap();
-            }
-            
-            let port = file_hash_result_pairs[index].port;
-            match get_filehash(file, port, None)
+                || file.starts_with("sftp://"))
             {
+                let mut receive_file = temp_folder.clone();
+                receive_file.push(file);
+                file = receive_file.into_os_string().into_string().unwrap();
+            }
+
+            let port = file_hash_result_pairs[index].port;
+            let size = file_hash_result_pairs[index].size;
+            match get_filehash(file, port, size) {
                 Ok(v) => assert_eq!(
                     v,
                     file_hash_result_pairs[index].hash_result.clone().unwrap()

--- a/shavee-lib/src/lib.rs
+++ b/shavee-lib/src/lib.rs
@@ -3,3 +3,5 @@ pub mod yubikey;
 pub mod filehash;
 pub mod password;
 pub mod logic;
+
+pub const UNREACHABLE_CODE : &str = "Panic! Something unexpected happened! Please help by reporting it as a bug.";

--- a/shavee-lib/src/logic.rs
+++ b/shavee-lib/src/logic.rs
@@ -1,5 +1,3 @@
-pub const UNREACHABLE_CODE : &str = "Panic! Something unexpected happened! Please help by reporting it as a bug.";
-
 use crate::password::hash_argon2;
 use crate::yubikey::*;
 use crate::zfs::*;
@@ -19,7 +17,7 @@ pub fn print_mode_yubi(pass: String, slot: u8) -> Result<(), Box<dyn Error>> {
 
 pub fn unlock_zfs_yubi(pass: String, dataset: Option<String>, slot: u8) -> Result<(), Box<dyn Error>> {
     let dataset = dataset
-        .expect(UNREACHABLE_CODE);
+        .expect(crate::UNREACHABLE_CODE);
 
     let key = yubi_key_calculation(pass, slot)?;
     zfs_loadkey(key, dataset.clone())?;
@@ -53,7 +51,7 @@ pub fn unlock_zfs_file(
     dataset: Option<String>
 ) -> Result<(),Box<dyn Error>> {
     let dataset = dataset
-        .expect(UNREACHABLE_CODE);
+        .expect(crate::UNREACHABLE_CODE);
     let key = file_key_calculation(pass, filehash)?;
     zfs_loadkey(key, dataset.clone())?;
     zfs_mount(dataset)?;
@@ -73,7 +71,7 @@ pub fn create_zfs_file(
 
 pub fn unlock_zfs_pass(key: String, dataset: Option<String>) -> Result<(), Box<dyn Error>> {
     let dataset = dataset
-        .expect(UNREACHABLE_CODE);
+        .expect(crate::UNREACHABLE_CODE);
     match zfs_list(dataset.clone()) {
         Ok(i) => {
             zfs_loadkey(key, dataset)?;

--- a/shavee-lib/src/logic.rs
+++ b/shavee-lib/src/logic.rs
@@ -1,3 +1,5 @@
+pub const UNREACHABLE_CODE : &str = "Panic! Something unexpected happened! Please help by reporting it as a bug.";
+
 use crate::filehash::get_filehash;
 use crate::password::hash_argon2;
 use crate::yubikey::*;
@@ -5,42 +7,59 @@ use crate::zfs::*;
 use base64::encode_config;
 use std::error::Error;
 
+fn yubi_key_calculation(pass: String, slot: u8) -> Result<String, Box<dyn Error>> {
+    let key = yubikey_get_hash(pass, slot)?;
+    Ok(encode_config(key, base64::STANDARD_NO_PAD))
+}
 
 pub fn print_mode_yubi(pass: String, slot: u8) -> Result<(), Box<dyn Error>> {
-    let key = yubikey_get_hash(pass, slot)?; // Get encryption key
-    let key = encode_config(key, base64::STANDARD_NO_PAD);
+    let key = yubi_key_calculation(pass, slot)?;
     println!("{}", key);
     Ok(())
 }
 
-pub fn print_mode_file(pass: String, file: &String, port: u16) -> Result<(), Box<dyn Error>> {
-    let passhash = hash_argon2(pass.into_bytes())?;
-    let filehash = get_filehash(file.clone(), port)?;
-    let key = [filehash, passhash].concat();
-    let key = hash_argon2(key)?;
-    let key = encode_config(key, base64::STANDARD_NO_PAD);
-    println!("{}", key);
-    Ok(())
-}
+pub fn unlock_zfs_yubi(pass: String, dataset: Option<String>, slot: u8) -> Result<(), Box<dyn Error>> {
+    let dataset = dataset
+        .expect(UNREACHABLE_CODE);
 
-pub fn unlock_zfs_yubi(pass: String, dataset: String, slot: u8) -> Result<(), Box<dyn Error>> {
-    let key = yubikey_get_hash(pass, slot)?; // Get encryption key
-    let key = encode_config(key, base64::STANDARD_NO_PAD);
+    let key = yubi_key_calculation(pass, slot)?;
     zfs_loadkey(key, dataset.clone())?;
     zfs_mount(dataset)?;
     Ok(())
 }
 
-pub fn unlock_zfs_file(
-    pass: String,
-    file: String,
-    dataset: String,
-    port: u16,
-) -> Result<(), Box<dyn Error>> {
+pub fn create_zfs_yubi(pass: String, zfspath: Option<String>, slot: u8) -> Result<(), Box<dyn Error>> {
+    let key = yubi_key_calculation(pass, slot)?;
+    zfs_create(key, zfspath)?;
+    Ok(())
+}
+
+fn file_key_calculation(pass: String, file: Option<String>, port: Option<u16>) -> Result<String, Box<dyn Error>> {
+    let file = file
+        .expect(UNREACHABLE_CODE);
     let passhash = hash_argon2(pass.into_bytes())?;
     let filehash = get_filehash(file.clone(), port)?;
     let key = [filehash, passhash].concat();
-    let key = encode_config(hash_argon2(key)?, base64::STANDARD_NO_PAD);
+    let key = hash_argon2(key)?;
+    let key = encode_config(key, base64::STANDARD_NO_PAD);
+    Ok(key)
+}
+
+pub fn print_mode_file(pass: String, file: Option<String>, port: Option<u16>) -> Result<(),Box<dyn Error>> {
+    let key = file_key_calculation(pass, file, port)?;
+    println!("{}", key);
+    Ok(())
+}
+
+pub fn unlock_zfs_file(
+    pass: String,
+    file: Option<String>,
+    dataset: Option<String>,
+    port: Option<u16>
+) -> Result<(),Box<dyn Error>> {
+    let dataset = dataset
+        .expect(UNREACHABLE_CODE);
+    let key = file_key_calculation(pass, file, port)?;
     zfs_loadkey(key, dataset.clone())?;
     zfs_mount(dataset)?;
     Ok(())
@@ -48,26 +67,19 @@ pub fn unlock_zfs_file(
 
 pub fn create_zfs_file(
     pass: String,
-    file: String,
-    dataset: String,
-    port: u16,
+    file: Option<String>,
+    dataset: Option<String>,
+    port: Option<u16>
 ) -> Result<(), Box<dyn Error>> {
-    let passhash = hash_argon2(pass.into_bytes())?;
-
-    let filehash = get_filehash(file.clone(), port)?;
-    let key = [filehash, passhash].concat();
-    let key = encode_config(hash_argon2(key)?, base64::STANDARD_NO_PAD);
+    let key = file_key_calculation(pass, file, port)?;
     zfs_create(key, dataset)?;
     Ok(())
 }
 
-pub fn create_zfs_yubi(pass: String, zfspath: String, slot: u8) -> Result<(), Box<dyn Error>> {
-    let key = encode_config(yubikey_get_hash(pass, slot)?, base64::STANDARD_NO_PAD); // Get encryption key
-    zfs_create(key, zfspath)?;
-    Ok(())
-}
 
-pub fn unlock_zfs_pass(key: String, dataset: String) -> Result<(), Box<dyn Error>> {
+pub fn unlock_zfs_pass(key: String, dataset: Option<String>) -> Result<(), Box<dyn Error>> {
+    let dataset = dataset
+        .expect(UNREACHABLE_CODE);
     match zfs_list(dataset.clone()) {
         Ok(i) => {
             zfs_loadkey(key, dataset)?;

--- a/shavee-lib/src/zfs.rs
+++ b/shavee-lib/src/zfs.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::io::prelude::*;
 use std::process::Command;
+use crate::logic::UNREACHABLE_CODE;
 
 pub fn zfs_loadkey(key: String, dataset: String) -> Result<(), Box<dyn Error>> {
     let zfs = Command::new("zfs") // Call zfs mount
@@ -74,7 +75,9 @@ pub fn zfs_list(dataset: String) -> Result<Vec<String>, Box<dyn Error>> {
     return Ok(dlist);
 }
 
-pub fn zfs_create(key: String, dataset: String) -> Result<(), Box<dyn Error>> {
+pub fn zfs_create(key: String, dataset: Option<String>) -> Result<(), Box<dyn Error>> {
+    let dataset = dataset
+        .expect(UNREACHABLE_CODE);
     let zfs_list = Command::new("zfs")
         .arg("list")
         .arg("-H")

--- a/shavee-lib/src/zfs.rs
+++ b/shavee-lib/src/zfs.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 use std::io::prelude::*;
 use std::process::Command;
-use crate::logic::UNREACHABLE_CODE;
 
 pub fn zfs_loadkey(key: String, dataset: String) -> Result<(), Box<dyn Error>> {
     let zfs = Command::new("zfs") // Call zfs mount
@@ -77,7 +76,7 @@ pub fn zfs_list(dataset: String) -> Result<Vec<String>, Box<dyn Error>> {
 
 pub fn zfs_create(key: String, dataset: Option<String>) -> Result<(), Box<dyn Error>> {
     let dataset = dataset
-        .expect(UNREACHABLE_CODE);
+        .expect(crate::UNREACHABLE_CODE);
     let zfs_list = Command::new("zfs")
         .arg("list")
         .arg("-H")

--- a/shavee-pam/src/lib.rs
+++ b/shavee-pam/src/lib.rs
@@ -26,7 +26,7 @@ impl PamServiceModule for PamShavee {
             .to_string_lossy()
             .to_string();
 
-        match shavee_lib::logic::unlock_zfs_yubi(pass, dataset, 2) {
+        match shavee_lib::logic::unlock_zfs_yubi(pass, Some(dataset), 2) {
             Ok(_) => return PamError::SUCCESS,
             Err(_) => return PamError::AUTH_ERR,
         }


### PR DESCRIPTION
This PR includes the implementation for #9 and #10.

1. Hash is now generated while user entering password.
2. Optional SIZE can be passed as CLI argument
2. Parse 'size' as 'Option<u64>'
3. Updated Plumping logic to pass variables to `lib` functions