### PR TITLE
Compile time config and graceful exits of unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "shavee"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "clap",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "shavee_pam"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "clap",

--- a/shavee-bin/Cargo.toml
+++ b/shavee-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shavee"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Ashutosh Verma <shavee@ashu.io>"]
 edition = "2018"
 license = "MIT"
@@ -10,9 +10,12 @@ documentation = "https://shavee.ashu.io"
 readme = "README.md"
 repository = "https://github.com/ashuio/shavee"
 
+[features]
+default = ["file", "yubikey"]
+yubikey = []
+file = []
 
 [dependencies]
-
 sha2 = "0.10.1"
 clap = { version = "3", features = ["cargo"] }
 rpassword = "5.0.1"

--- a/shavee-bin/src/main.rs
+++ b/shavee-bin/src/main.rs
@@ -231,7 +231,8 @@ mod tests {
         } // END **Integration Test**: Print File
 
         // **Integration Test**: Create from password then mount it
-        {
+        // This test will only run if there is root persmission
+        if nix::unistd::Uid::effective().is_root() {
             let (zpool_name, temp_folder) = prepare_zpool();
 
             let mut zpool_with_dataset = zpool_name.to_owned();
@@ -367,8 +368,9 @@ mod tests {
         } //END  **Integration Test**: Create from File then mount it
 
         // **Integration Test**: Create from File then mount it
+        // This test will only run if there is root persmission
         #[cfg(feature = "file")]
-        {
+        if nix::unistd::Uid::effective().is_root() {
             let (zpool_name, temp_folder) = prepare_zpool();
 
             let mut zpool_with_dataset = zpool_name.to_owned();

--- a/shavee-core/Cargo.toml
+++ b/shavee-core/Cargo.toml
@@ -3,9 +3,7 @@ name = "shavee_core"
 version = "0.5.0"
 edition = "2018"
 
-
 [dependencies]
-
 yubico_manager = "0.9.0"
 sha2 = "0.10.1"
 curl = "0.4.38"

--- a/shavee-core/src/filehash.rs
+++ b/shavee-core/src/filehash.rs
@@ -359,10 +359,10 @@ mod tests {
                 size: None,
                 port: Some(80),
                 hash_result: Ok(vec![
-                    243, 179, 171, 62, 99, 81, 226, 91, 92, 24, 130, 190, 168, 211, 126, 250, 221,
-                    192, 234, 114, 191, 21, 59, 176, 103, 104, 143, 119, 90, 38, 129, 13, 50, 181,
-                    79, 1, 75, 241, 206, 188, 127, 233, 48, 66, 216, 91, 24, 181, 180, 83, 227, 34,
-                    209, 84, 188, 85, 213, 204, 39, 84, 176, 223, 180, 178,
+                    207, 131, 225, 53, 126, 239, 184, 189, 241, 84, 40, 80, 214, 109, 128, 7, 214,
+                    32, 228, 5, 11, 87, 21, 220, 131, 244, 169, 33, 211, 108, 233, 206, 71, 208,
+                    209, 60, 93, 133, 242, 176, 255, 131, 24, 210, 135, 126, 236, 47, 99, 185, 49,
+                    189, 71, 65, 122, 129, 165, 56, 50, 122, 249, 39, 218, 62,
                 ]),
             },
             FilePortHashResultPair {
@@ -431,6 +431,7 @@ mod tests {
             let file = file_hash_result_pairs[index].file.clone();
             let port = file_hash_result_pairs[index].port;
             let size = file_hash_result_pairs[index].size;
+            println!("{:?}", index); // in case of test failure shows which index caused it
 
             match get_filehash_http_sftp(file, port, size) {
                 Ok(v) => assert_eq!(
@@ -538,10 +539,10 @@ mod tests {
                 size: Some(1 << 15),
                 port: Some(80),
                 hash_result: Ok(vec![
-                    243, 179, 171, 62, 99, 81, 226, 91, 92, 24, 130, 190, 168, 211, 126, 250, 221,
-                    192, 234, 114, 191, 21, 59, 176, 103, 104, 143, 119, 90, 38, 129, 13, 50, 181,
-                    79, 1, 75, 241, 206, 188, 127, 233, 48, 66, 216, 91, 24, 181, 180, 83, 227, 34,
-                    209, 84, 188, 85, 213, 204, 39, 84, 176, 223, 180, 178,
+                    207, 131, 225, 53, 126, 239, 184, 189, 241, 84, 40, 80, 214, 109, 128, 7, 214,
+                    32, 228, 5, 11, 87, 21, 220, 131, 244, 169, 33, 211, 108, 233, 206, 71, 208,
+                    209, 60, 93, 133, 242, 176, 255, 131, 24, 210, 135, 126, 236, 47, 99, 185, 49,
+                    189, 71, 65, 122, 129, 165, 56, 50, 122, 249, 39, 218, 62,
                 ]),
             },
             FilePortHashResultPair {
@@ -622,6 +623,7 @@ mod tests {
                 file = receive_file.into_os_string().into_string().unwrap();
             }
 
+            println!("{:?}", index); // in case of test failure it shows which index caused it
             let port = file_hash_result_pairs[index].port;
             let size = file_hash_result_pairs[index].size;
             match get_filehash(file, port, size) {

--- a/shavee-core/src/zfs.rs
+++ b/shavee-core/src/zfs.rs
@@ -256,180 +256,189 @@ mod tests {
     }
     #[test]
     fn zfs_mount_umount_test() {
-        // generate a temp zpool
-        let (zpool_name, temp_folder) = prepare_zpool();
-        // b/c of zpool creation process, the dataset name is the same as zpool
-        let zfs_dataset = Dataset {
-            dataset: zpool_name.clone(),
-        };
+        // This test will only run if there is root persmission
+        if nix::unistd::Uid::effective().is_root() {
+            // generate a temp zpool
+            let (zpool_name, temp_folder) = prepare_zpool();
+            // b/c of zpool creation process, the dataset name is the same as zpool
+            let zfs_dataset = Dataset {
+                dataset: zpool_name.clone(),
+            };
 
-        // NOTE: the output will be evaluated **AFTER** clean up so the temp folder and
-        // temp zpool can safely be removed.
+            // NOTE: the output will be evaluated **AFTER** clean up so the temp folder and
+            // temp zpool can safely be removed.
 
-        // **Test 1**: umount a dataset
-        let test_umount_output = zfs_dataset.umount();
+            // **Test 1**: umount a dataset
+            let test_umount_output = zfs_dataset.umount();
 
-        // **Test 2**: umount an already unmounted dataset
-        // This test is expected to fail!
-        let test_already_unmounted_dataset_output = zfs_dataset.umount();
+            // **Test 2**: umount an already unmounted dataset
+            // This test is expected to fail!
+            let test_already_unmounted_dataset_output = zfs_dataset.umount();
 
-        // **Test 3**: mount an unmounted dataset
-        let test_mount_output = zfs_dataset.mount();
+            // **Test 3**: mount an unmounted dataset
+            let test_mount_output = zfs_dataset.mount();
 
-        // **Test 4**: mount an already mounted dataset
-        // This test is expected to fail!
-        let test_already_mount_again_output = zfs_dataset.mount();
+            // **Test 4**: mount an already mounted dataset
+            // This test is expected to fail!
+            let test_already_mount_again_output = zfs_dataset.mount();
 
-        //clean up
-        cleanup_zpool(&zpool_name, temp_folder);
+            //clean up
+            cleanup_zpool(&zpool_name, temp_folder);
 
-        // **Test 1**
-        // test the output against expected result.
-        test_umount_output.expect("umount(): Dataset umount failed!");
+            // **Test 1**
+            // test the output against expected result.
+            test_umount_output.expect("umount(): Dataset umount failed!");
 
-        // **Test 2** Expected to fail
-        match test_already_unmounted_dataset_output {
-            Ok(_) => panic!("umount() on an already unmounted dataset failed!"),
-            Err(error) => assert_eq!(
-                format!(
-                    "cannot unmount '{}': not currently mounted\n",
-                    zfs_dataset.dataset
+            // **Test 2** Expected to fail
+            match test_already_unmounted_dataset_output {
+                Ok(_) => panic!("umount() on an already unmounted dataset failed!"),
+                Err(error) => assert_eq!(
+                    format!(
+                        "cannot unmount '{}': not currently mounted\n",
+                        zfs_dataset.dataset
+                    ),
+                    error.to_string()
                 ),
-                error.to_string()
-            ),
-        }
+            }
 
-        // **Test 3**
-        // test the output against expected result.
-        test_mount_output.expect("mount(): Dataset mount failed!");
+            // **Test 3**
+            // test the output against expected result.
+            test_mount_output.expect("mount(): Dataset mount failed!");
 
-        // **Test 4** Expected to fail
-        match test_already_mount_again_output {
-            Ok(_) => panic!("mount() on an already mounted dataset failed!"),
-            Err(error) => assert_eq!(
-                format!(
-                    "cannot mount '{}': filesystem already mounted\n",
-                    zfs_dataset.dataset
+            // **Test 4** Expected to fail
+            match test_already_mount_again_output {
+                Ok(_) => panic!("mount() on an already mounted dataset failed!"),
+                Err(error) => assert_eq!(
+                    format!(
+                        "cannot mount '{}': filesystem already mounted\n",
+                        zfs_dataset.dataset
+                    ),
+                    error.to_string()
                 ),
-                error.to_string()
-            ),
+            }
         }
     }
 
     #[test]
     fn zfs_list_test() {
-        // generate a temp zpool
-        let (zpool_name, temp_folder) = prepare_zpool();
-        // b/c of zpool creation process, the dataset name is the same as zpool
-        let zfs_dataset = Dataset {
-            dataset: zpool_name.clone(),
-        };
+        // This test will only run if there is root persmission
+        if nix::unistd::Uid::effective().is_root() {
+            // generate a temp zpool
+            let (zpool_name, temp_folder) = prepare_zpool();
+            // b/c of zpool creation process, the dataset name is the same as zpool
+            let zfs_dataset = Dataset {
+                dataset: zpool_name.clone(),
+            };
 
-        // NOTE: the output will be evaluated **AFTER** clean up so the temp folder and
-        // temp zpool can safely be removed.
+            // NOTE: the output will be evaluated **AFTER** clean up so the temp folder and
+            // temp zpool can safely be removed.
 
-        let test_output = zfs_dataset.list();
+            let test_output = zfs_dataset.list();
 
-        //clean up
-        cleanup_zpool(&zpool_name, temp_folder);
+            //clean up
+            cleanup_zpool(&zpool_name, temp_folder);
 
-        // test the output against expected result.
-        match test_output {
-            Ok(result) => assert_eq!(
-                result,
-                vec![Dataset {
-                    dataset: zpool_name
-                }]
-            ),
-            Err(error) => panic!("list(): Test failed: {:?}", error),
+            // test the output against expected result.
+            match test_output {
+                Ok(result) => assert_eq!(
+                    result,
+                    vec![Dataset {
+                        dataset: zpool_name
+                    }]
+                ),
+                Err(error) => panic!("list(): Test failed: {:?}", error),
+            }
         }
     }
 
     #[test]
     fn zfs_create_load_unload_key_test() {
-        // generate a temp zpool
-        let (zpool_name, temp_folder) = prepare_zpool();
+        // This test will only run if there is root persmission
+        if nix::unistd::Uid::effective().is_root() {
+            // generate a temp zpool
+            let (zpool_name, temp_folder) = prepare_zpool();
 
-        // b/c of zpool creation process, the dataset name is the same as zpool
-        let zfs_plan_dataset = Dataset {
-            dataset: zpool_name.clone(),
-        };
+            // b/c of zpool creation process, the dataset name is the same as zpool
+            let zfs_plan_dataset = Dataset {
+                dataset: zpool_name.clone(),
+            };
 
-        // NOTE: the output will be evaluated **AFTER** clean up so the temp folder and
-        // temp zpool can safely be removed.
+            // NOTE: the output will be evaluated **AFTER** clean up so the temp folder and
+            // temp zpool can safely be removed.
 
-        // **TEST 1**: create() on a dataset that is not encrypted
-        // This test is expected to fail!
-        let test_dataset_not_encrypted_must_fail_output =
-            zfs_plan_dataset.create(&random_string(3));
+            // **TEST 1**: create() on a dataset that is not encrypted
+            // This test is expected to fail!
+            let test_dataset_not_encrypted_must_fail_output =
+                zfs_plan_dataset.create(&random_string(3));
 
-        // **TEST 2**: create() a new encrypted dataset
-        let mut zpool_with_dataset = zpool_name.to_owned();
-        zpool_with_dataset.push('/');
-        zpool_with_dataset.push_str(&random_string(3));
-        let zfs_encrypted_dataset = Dataset {
-            dataset: zpool_with_dataset,
-        };
-        let test_create_new_encrypted_dataset_output =
-            zfs_encrypted_dataset.create(&random_string(8)); // min accepted key is 8 character
+            // **TEST 2**: create() a new encrypted dataset
+            let mut zpool_with_dataset = zpool_name.to_owned();
+            zpool_with_dataset.push('/');
+            zpool_with_dataset.push_str(&random_string(3));
+            let zfs_encrypted_dataset = Dataset {
+                dataset: zpool_with_dataset,
+            };
+            let test_create_new_encrypted_dataset_output =
+                zfs_encrypted_dataset.create(&random_string(8)); // min accepted key is 8 character
 
-        // **TEST 3**: create() on an already encrypted dataset with a known passphrase
-        // ZFS min accepted passphrase is 8 character
-        let passphrase = random_string(8);
-        let test_already_encrypted_dataset_output = zfs_encrypted_dataset.create(&passphrase);
+            // **TEST 3**: create() on an already encrypted dataset with a known passphrase
+            // ZFS min accepted passphrase is 8 character
+            let passphrase = random_string(8);
+            let test_already_encrypted_dataset_output = zfs_encrypted_dataset.create(&passphrase);
 
-        // **Test 4**: unloadkey() on a mounted dataset
-        // This test is expected to fail!
-        let test_unload_key_mounted_dataset_output = zfs_encrypted_dataset.unloadkey();
+            // **Test 4**: unloadkey() on a mounted dataset
+            // This test is expected to fail!
+            let test_unload_key_mounted_dataset_output = zfs_encrypted_dataset.unloadkey();
 
-        // **Test 5**: unloadkey() on a unmounted dataset
-        zfs_encrypted_dataset
-            .umount()
-            .expect("Test terminated unexpectedly early!");
-        let test_unload_key_unmounted_dataset_output = zfs_encrypted_dataset.unloadkey();
+            // **Test 5**: unloadkey() on a unmounted dataset
+            zfs_encrypted_dataset
+                .umount()
+                .expect("Test terminated unexpectedly early!");
+            let test_unload_key_unmounted_dataset_output = zfs_encrypted_dataset.unloadkey();
 
-        // **Test 6**: loadkey() on a unmounted dataset
-        let test_load_key_unmounted_dataset_output = zfs_encrypted_dataset.loadkey(&passphrase);
+            // **Test 6**: loadkey() on a unmounted dataset
+            let test_load_key_unmounted_dataset_output = zfs_encrypted_dataset.loadkey(&passphrase);
 
-        //clean up
-        cleanup_zpool(&zpool_name, temp_folder);
+            //clean up
+            cleanup_zpool(&zpool_name, temp_folder);
 
-        // now it is time to test the outputs against expected results.
+            // now it is time to test the outputs against expected results.
 
-        // **TEST 1**: create() on a dataset that is not encrypted
-        match test_dataset_not_encrypted_must_fail_output {
-            Ok(_) => panic!("create(): Set a new passphrase on an unencrypted dataset failed!"),
-            Err(error) => assert_eq!(
-                "Key change error: Dataset not encrypted.\n",
-                error.to_string()
-            ),
-        }
-
-        // **TEST 2**: create() a new encrypted dataset
-        test_create_new_encrypted_dataset_output
-            .expect("create(): Create new encrypted dataset failed!");
-
-        // **TEST 3**: create() on an already encrypted dataset
-        test_already_encrypted_dataset_output
-            .expect("create(): Set a new passphrase on an encrypted dataset failed!");
-
-        // **Test 4**: unloadkey() on a mounted dataset
-        match test_unload_key_mounted_dataset_output {
-            Ok(_) => panic!("unloadkey() on a mounted dataset failed!"),
-            Err(error) => assert_eq!(
-                format!(
-                    "Key unload error: '{}' is busy.\n",
-                    zfs_encrypted_dataset.dataset
+            // **TEST 1**: create() on a dataset that is not encrypted
+            match test_dataset_not_encrypted_must_fail_output {
+                Ok(_) => panic!("create(): Set a new passphrase on an unencrypted dataset failed!"),
+                Err(error) => assert_eq!(
+                    "Key change error: Dataset not encrypted.\n",
+                    error.to_string()
                 ),
-                error.to_string()
-            ),
+            }
+
+            // **TEST 2**: create() a new encrypted dataset
+            test_create_new_encrypted_dataset_output
+                .expect("create(): Create new encrypted dataset failed!");
+
+            // **TEST 3**: create() on an already encrypted dataset
+            test_already_encrypted_dataset_output
+                .expect("create(): Set a new passphrase on an encrypted dataset failed!");
+
+            // **Test 4**: unloadkey() on a mounted dataset
+            match test_unload_key_mounted_dataset_output {
+                Ok(_) => panic!("unloadkey() on a mounted dataset failed!"),
+                Err(error) => assert_eq!(
+                    format!(
+                        "Key unload error: '{}' is busy.\n",
+                        zfs_encrypted_dataset.dataset
+                    ),
+                    error.to_string()
+                ),
+            }
+
+            // **Test 5**: unloadkey() on a unmounted dataset
+            test_unload_key_unmounted_dataset_output.expect("unloadkey() failed!");
+
+            // **Test 6**: zfs_loadkey() on a unmounted dataset
+            test_load_key_unmounted_dataset_output.expect("loadkey() failed!");
         }
-
-        // **Test 5**: unloadkey() on a unmounted dataset
-        test_unload_key_unmounted_dataset_output.expect("unloadkey() failed!");
-
-        // **Test 6**: zfs_loadkey() on a unmounted dataset
-        test_load_key_unmounted_dataset_output.expect("loadkey() failed!");
     }
 
     //These tests checks for a reported error on non-existing dataset

--- a/shavee-pam/Cargo.toml
+++ b/shavee-pam/Cargo.toml
@@ -1,13 +1,18 @@
 [package]
 name = "shavee_pam"
 authors = ["Ashutosh Verma <shavee@ashu.io>"]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2018"
 license = "MIT"
 
 [lib]
 crate-type = ["cdylib"]
 name = "shavee_pam"
+
+[features]
+default = ["yubikey", "file"]
+yubikey = []
+file = []
 
 [dependencies]
 pamsm = { version="0.5.0", features=["libpam"] }

--- a/shavee-pam/src/lib.rs
+++ b/shavee-pam/src/lib.rs
@@ -5,7 +5,10 @@ extern crate pamsm;
 
 use base64;
 use pamsm::{Pam, PamError, PamFlags, PamLibExt, PamServiceModule};
-use shavee_core::{filehash, password, zfs::Dataset};
+#[cfg(feature = "file")]
+use shavee_core::filehash;
+use shavee_core::password;
+use shavee_core::zfs::Dataset;
 struct PamShavee;
 
 // TODO: Need unit tests implemented for the PAM module functions
@@ -51,8 +54,10 @@ impl PamServiceModule for PamShavee {
         };
 
         let result = match umode {
+            #[cfg(feature = "yubikey")]
             args::TwoFactorMode::Yubikey { yslot } => dataset.yubi_unlock(pass, yslot),
 
+            #[cfg(feature = "file")]
             args::TwoFactorMode::File { file, port, size } => {
                 let filehash = match filehash::get_filehash(file, port, size) {
                     Ok(error) => error,


### PR DESCRIPTION
This PR implements the following:

1. The feature that is requested in #24 by adding compile time features `yubikey` and `file` in `Cargo.toml`.
   * Please note that the binary and PAM module have different `Cargo.toml` and the features can be turned on and off in each independently
2. It now exits gracefully instead of causing `panic`, if root permission is not granted or ZFS tools is not installed for unit tests that depend on them.
2. It up-ticked a minor revision to `0.5.1`